### PR TITLE
Add PyTorch implementation of CableRouting

### DIFF
--- a/CalbleRouting_pytorch/README.md
+++ b/CalbleRouting_pytorch/README.md
@@ -1,0 +1,43 @@
+# CableRouting (PyTorch)
+
+This directory contains a PyTorch reimplementation of the CableRouting behaviour cloning project.
+
+## Installation
+
+```shell
+git clone git@github.com:tan-liam/CableRouting.git
+cd CableRouting/CalbleRouting_pytorch
+pip install -r requirements.txt
+```
+
+The implementation automatically uses a CUDA device when available. You can force CPU execution by passing `--device=cpu` to the training scripts.
+
+## Training scripts
+
+Set your `WANDB_API_KEY` in the shell scripts under `local_scripts/` and update the dataset paths before launching experiments.
+
+```shell
+local_scripts/pretrain_resnet_embedding.sh
+local_scripts/train_routing_bc.sh
+local_scripts/train_highlevel.sh
+local_scripts/finetune_highlevel.sh
+```
+
+### Behaviour cloning
+
+`CalbleRouting_pytorch/src/bc_main.py` trains the low-level policy. Provide the route dataset via the `--dataset_path` flag. When `--save_model=True`, checkpoints contain PyTorch `state_dict`s for the model and optimizer.
+
+### Primitive selection
+
+`CalbleRouting_pytorch/src/primitive_selection_main.py` trains the high-level primitive selector. Use `--encoder_checkpoint_path` to load the pretrained features policy produced by `bc_main.py`.
+
+## Checkpoints
+
+Saved checkpoints are Python pickles containing:
+
+* `variant`: configuration dictionary captured from flags.
+* `model_state_dict`: PyTorch `state_dict` for the current model.
+* `optimizer_state_dict`: optimizer state.
+* `best_*_model_state_dict`: copies of the best performing model parameters according to validation metrics.
+
+These files can be loaded with `cloudpickle.load` and fed back into the training scripts via the appropriate flags.

--- a/CalbleRouting_pytorch/data/process_route_trajectories.py
+++ b/CalbleRouting_pytorch/data/process_route_trajectories.py
@@ -1,0 +1,93 @@
+import argparse
+import glob
+import os
+
+import numpy as np
+from scipy.spatial.transform import Rotation as R
+from tqdm import tqdm
+
+
+def rotate_action_frame(data):
+    states = data["robot_state"]
+    actions = data["action"]
+
+    for i in tqdm(range(states.shape[0])):
+        state = states[i]
+        action = actions[i]
+
+        r = R.from_quat(state[3:7])
+        r = r.as_matrix()
+
+        p = state[:3]
+        p_hat = np.array(
+            [[0, -p[2], p[1]], [p[2], 0, -p[0]], [-p[1], p[0], 0]]
+        )
+
+        adjoint = np.zeros((6, 6))
+        adjoint[:3, :3] = r
+        adjoint[3:, :3] = p_hat @ r
+        adjoint[3:, 3:] = r
+
+        V_s = np.zeros((6,))
+        V_s[:3] = action[:3]
+        V_s[5] = action[3]
+
+        V_b = adjoint @ V_s
+
+        action[:3] = V_b[:3]
+        action[3] = V_b[5]
+
+        actions[i] = action
+
+    actions = np.clip(actions, -1, 1)
+    data["action"] = actions
+    return data
+
+
+def process_trajectories_into_transitions(trajectories):
+    actions = []
+    robot_state = []
+    side_image = []
+    top_image = []
+    wrist45_image = []
+    wrist225_image = []
+
+    output = dict()
+
+    for traj in trajectories:
+        traj_npy = np.load(os.path.join(traj, "traj.npy"), allow_pickle=True).item()
+
+        actions += traj_npy["actions"]
+        robot_state += traj_npy["observations/tcp_pose"]
+        side_image += traj_npy["observations/side"]
+        top_image += traj_npy["observations/top"]
+        wrist45_image += traj_npy["observations/wrist45"]
+        wrist225_image += traj_npy["observations/wrist225"]
+
+    output["action"] = np.array(actions)
+    output["robot_state"] = np.array(robot_state)
+    output["side_image"] = np.array(side_image)
+    output["top_image"] = np.array(top_image)
+    output["wrist45_image"] = np.array(wrist45_image)
+    output["wrist225_image"] = np.array(wrist225_image)
+
+    output = rotate_action_frame(output)
+
+    return output
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--trajectory_path", type=str, help="Path to the route trajectories directory"
+    )
+    parser.add_argument(
+        "--output_path", type=str, help="Path to the output directory"
+    )
+    args = parser.parse_args()
+
+    trajectories = glob.glob(os.path.join(args.trajectory_path, "*"))
+    processed = process_trajectories_into_transitions(trajectories)
+
+    os.makedirs(args.output_path, exist_ok=True)
+    np.save(os.path.join(args.output_path, "route_transitions.npy"), processed)

--- a/CalbleRouting_pytorch/local_scripts/finetune_highlevel.sh
+++ b/CalbleRouting_pytorch/local_scripts/finetune_highlevel.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+EXP_NAME='{INSERT NAME HERE}'
+OUTPUT_DIR='{INSERT PATH HERE}'
+export PROJECT_HOME="$(pwd)"
+export PYTHONPATH="$PYTHONPATH:$PROJECT_HOME/CalbleRouting_pytorch/src"
+export WANDB_API_KEY='{INSERT WANDB_API_KEY}'
+
+for WEIGHT_DECAY in 1e-2
+do
+    python -m CalbleRouting_pytorch.src.primitive_selection_main \
+        --dataset_path="{INSERT PATH HERE}" \
+        --encoder_checkpoint_path="{INSERT PATH HERE}" \
+        --primitive_policy_checkpoint_path='{INSERT PATH HERE}' \
+        --seed=24 \
+        --dataset_image_keys='wrist45_image:wrist225_image:side_image' \
+        --image_augmentation='rand' \
+        --eval_freq=10 \
+        --batch_size=128 \
+        --save_model=True \
+        --lr=3e-5 \
+        --lr_warmup_steps=50 \
+        --weight_decay=$WEIGHT_DECAY \
+        --policy.spatial_aggregate='average' \
+        --policy.resnet_type='ResNet18' \
+        --policy.state_injection='z_only' \
+        --policy.share_resnet_between_views=False \
+        --logger.output_dir="$OUTPUT_DIR/$EXP_NAME" \
+        --logger.online=True \
+        --logger.prefix='CableRouting' \
+        --logger.project="$EXP_NAME" \
+        --finetune_policy=True \
+        --finetune_steps=1000
+done

--- a/CalbleRouting_pytorch/local_scripts/pretrain_resnet_embedding.sh
+++ b/CalbleRouting_pytorch/local_scripts/pretrain_resnet_embedding.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+EXP_NAME='{INSERT NAME HERE}'
+OUTPUT_DIR='{INSERT PATH HERE}'
+export PROJECT_HOME="$(pwd)"
+export PYTHONPATH="$PYTHONPATH:$PROJECT_HOME/CalbleRouting_pytorch/src"
+export WANDB_API_KEY='{INSERT WANDB_API_KEY}'
+
+for WEIGHT_DECAY in 1e-2 3e-2
+do
+    python -m CalbleRouting_pytorch.src.bc_main \
+        --dataset_path="{INSERT PATH HERE}" \
+        --seed=24 \
+        --dataset_image_keys='wrist45_image:wrist225_image:side_image' \
+        --image_augmentation='rand' \
+        --total_steps=6000 \
+        --eval_freq=100 \
+        --batch_size=512 \
+        --save_model=True \
+        --lr=1e-3 \
+        --weight_decay=$WEIGHT_DECAY \
+        --policy_class_name="PretrainTanhGaussianResNetPolicy" \
+        --policy.spatial_aggregate='average' \
+        --policy.resnet_type='ResNet18' \
+        --policy.state_injection='z_only' \
+        --policy.share_resnet_between_views=False \
+        --logger.output_dir="$OUTPUT_DIR/$EXP_NAME" \
+        --logger.online=True \
+        --logger.prefix='CableRouting' \
+        --logger.project="$EXP_NAME"
+done

--- a/CalbleRouting_pytorch/local_scripts/train_highlevel.sh
+++ b/CalbleRouting_pytorch/local_scripts/train_highlevel.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+EXP_NAME='{INSERT NAME HERE}'
+OUTPUT_DIR='{INSERT DIR HERE}'
+export PROJECT_HOME="$(pwd)"
+export PYTHONPATH="$PYTHONPATH:$PROJECT_HOME/CalbleRouting_pytorch/src"
+export WANDB_API_KEY='{INSERT WANDB_API_KEY}'
+
+python -m CalbleRouting_pytorch.src.primitive_selection_main \
+    --encoder_checkpoint_path="{INSERT PATH HERE}" \
+    --dataset_path="{INSERT PATH HERE}" \
+    --seed=24 \
+    --dataset_image_keys='wrist45_image:wrist225_image:side_image' \
+    --image_augmentation='rand' \
+    --total_steps=30000 \
+    --eval_freq=100 \
+    --batch_size=128 \
+    --save_model=True \
+    --lr=3e-4 \
+    --weight_decay=1e-2 \
+    --policy.spatial_aggregate='average' \
+    --policy.resnet_type='ResNet18' \
+    --policy.state_injection='z_only' \
+    --policy.share_resnet_between_views=False \
+    --logger.output_dir="$OUTPUT_DIR/$EXP_NAME" \
+    --logger.online=True \
+    --logger.prefix='CableRouting' \
+    --logger.project="$EXP_NAME"

--- a/CalbleRouting_pytorch/local_scripts/train_routing_bc.sh
+++ b/CalbleRouting_pytorch/local_scripts/train_routing_bc.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+EXP_NAME='{INSERT NAME HERE}'
+OUTPUT_DIR='{INSERT PATH HERE}'
+export PROJECT_HOME="$(pwd)"
+export PYTHONPATH="$PYTHONPATH:$PROJECT_HOME/CalbleRouting_pytorch/src"
+export WANDB_API_KEY='{INSERT WANDB_API_KEY HERE}'
+
+for IMAGE_AUG in 'rand'
+do
+    for WEIGHT_DECAY in 3e-3
+    do
+        python -m CalbleRouting_pytorch.src.bc_main \
+            --dataset_path="./test_route.npy" \
+            --seed=24 \
+            --dataset_image_keys='wrist45_image:wrist225_image' \
+            --image_augmentation=${IMAGE_AUG} \
+            --total_steps=20000 \
+            --eval_freq=100 \
+            --batch_size=256 \
+            --save_model=True \
+            --lr=1e-3 \
+            --weight_decay=$WEIGHT_DECAY \
+            --policy_class_name="TanhGaussianResNetPolicy" \
+            --policy.spatial_aggregate='average' \
+            --policy.resnet_type='ResNet18' \
+            --policy.state_injection='z_only' \
+            --policy.share_resnet_between_views=False \
+            --logger.output_dir="$OUTPUT_DIR/$EXP_NAME" \
+            --logger.online=True \
+            --logger.prefix='CableRouting' \
+            --logger.project="$EXP_NAME"
+    done
+done

--- a/CalbleRouting_pytorch/requirements.txt
+++ b/CalbleRouting_pytorch/requirements.txt
@@ -1,0 +1,10 @@
+absl-py
+cloudpickle
+ml_collections
+numpy
+scipy
+torch
+torchvision
+tqdm
+wandb
+Pillow

--- a/CalbleRouting_pytorch/src/bc_main.py
+++ b/CalbleRouting_pytorch/src/bc_main.py
@@ -1,0 +1,231 @@
+import importlib
+import pprint
+from copy import deepcopy
+
+import absl.app
+import absl.flags
+import numpy as np
+import torch
+
+from .data import (
+    partition_batch_train_test,
+    subsample_batch,
+    preprocess_robot_dataset,
+    augment_batch,
+    get_data_augmentation,
+    concatenate_batches,
+)
+from .utils import (
+    define_flags_with_default,
+    set_random_seed,
+    get_user_flags,
+    WandBLogger,
+    average_metrics,
+)
+from .train_utils import (
+    get_learning_rate,
+    get_optimizer,
+)
+from .model import ResNetPolicy, TanhGaussianResNetPolicy, PretrainTanhGaussianResNetPolicy
+
+
+FLAGS_DEF = define_flags_with_default(
+    seed=42,
+    dataset_path="",
+    dataset_image_keys="side_image",
+    image_augmentation="none",
+    clip_action=0.99,
+    train_ratio=0.9,
+    batch_size=128,
+    total_steps=10000,
+    lr=1e-4,
+    lr_warmup_steps=0,
+    weight_decay=0.05,
+    clip_gradient=1e9,
+    log_freq=50,
+    eval_freq=200,
+    eval_batches=20,
+    save_model=False,
+    policy_class_name="TanhGaussianResNetPolicy",
+    policy=TanhGaussianResNetPolicy.get_default_config(),
+    logger=WandBLogger.get_default_config(),
+    device="auto",
+)
+
+FLAGS = absl.flags.FLAGS
+
+
+def _get_device(device_flag: str) -> torch.device:
+    if device_flag.lower() == "cpu":
+        return torch.device("cpu")
+    if device_flag.lower() == "cuda" and torch.cuda.is_available():
+        return torch.device("cuda")
+    if device_flag.lower() == "auto":
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    return torch.device(device_flag)
+
+
+def _to_device(array, device):
+    if isinstance(array, torch.Tensor):
+        tensor = array
+    else:
+        tensor = torch.from_numpy(np.asarray(array))
+    return tensor.to(device=device, dtype=torch.float32)
+
+
+def _clone_state_dict(model: torch.nn.Module):
+    return {k: v.detach().cpu().clone() for k, v in model.state_dict().items()}
+
+
+def main(argv):
+    del argv
+    assert FLAGS.dataset_path != ""
+    policy_module = importlib.import_module("CalbleRouting_pytorch.src.model")
+    policy_class = getattr(policy_module, FLAGS.policy_class_name)
+    variant = get_user_flags(FLAGS, FLAGS_DEF)
+    wandb_logger = WandBLogger(config=FLAGS.logger, variant=variant)
+    set_random_seed(FLAGS.seed)
+
+    image_keys = FLAGS.dataset_image_keys.split(":")
+    dataset = np.load(FLAGS.dataset_path, allow_pickle=True)
+    if isinstance(dataset, np.ndarray) and dataset.shape == ():
+        dataset = dataset.item()
+    if isinstance(dataset, np.ndarray):
+        dataset = concatenate_batches(dataset)
+    elif isinstance(dataset, dict):
+        dataset = deepcopy(dataset)
+    else:
+        raise TypeError("Unsupported dataset format")
+    dataset = preprocess_robot_dataset(dataset, FLAGS.clip_action)
+    train_dataset, test_dataset = partition_batch_train_test(dataset, FLAGS.train_ratio)
+
+    device = _get_device(FLAGS.device)
+    policy = policy_class(
+        output_dim=dataset["action"].shape[-1],
+        config_updates=FLAGS.policy,
+    ).to(device)
+
+    learning_rate = get_learning_rate(FLAGS=FLAGS)
+
+    if FLAGS.policy_class_name == "TanhGaussianResNetPolicy":
+        optimizer = get_optimizer(
+            model=policy,
+            learning_rate=FLAGS.lr,
+            weight_decay=FLAGS.weight_decay,
+            exclusions=TanhGaussianResNetPolicy.get_weight_decay_exclusions(),
+        )
+    elif FLAGS.policy_class_name == "PretrainTanhGaussianResNetPolicy":
+        optimizer = get_optimizer(
+            model=policy,
+            learning_rate=FLAGS.lr,
+            weight_decay=FLAGS.weight_decay,
+            exclusions=PretrainTanhGaussianResNetPolicy.get_weight_decay_exclusions(),
+        )
+    elif FLAGS.policy_class_name == "ResNetPolicy":
+        optimizer = get_optimizer(
+            model=policy,
+            learning_rate=FLAGS.lr,
+            weight_decay=FLAGS.weight_decay,
+            exclusions=ResNetPolicy.get_weight_decay_exclusions(),
+        )
+    else:
+        raise ValueError(f"{FLAGS.policy_class_name} is not a valid policy")
+
+    augmentation = get_data_augmentation(FLAGS.image_augmentation)
+
+    best_loss, best_mse = float("inf"), float("inf")
+    best_loss_model, best_mse_model = None, None
+
+    def train_step(step, batch):
+        policy.train()
+        state = _to_device(batch["robot_state"], device)
+        action = _to_device(batch["action"], device)
+        images = [_to_device(batch[key], device) for key in image_keys]
+        optimizer.zero_grad(set_to_none=True)
+        log_probs, mean = policy.log_prob(state, action, images, return_mean=True)
+        loss = -log_probs.mean()
+        mse = torch.mean(torch.sum((mean - action) ** 2, dim=-1))
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(policy.parameters(), FLAGS.clip_gradient)
+        current_lr = learning_rate(step)
+        for param_group in optimizer.param_groups:
+            param_group["lr"] = current_lr
+        optimizer.step()
+        metrics = dict(
+            loss=loss.item(),
+            mse=mse.item(),
+            learning_rate=current_lr,
+        )
+        return metrics
+
+    @torch.no_grad()
+    def eval_step(batch):
+        policy.eval()
+        state = _to_device(batch["robot_state"], device)
+        action = _to_device(batch["action"], device)
+        images = [_to_device(batch[key], device) for key in image_keys]
+        log_probs, mean = policy.log_prob(state, action, images, return_mean=True)
+        loss = -log_probs.mean()
+        mse = torch.mean(torch.sum((mean - action) ** 2, dim=-1))
+        metrics = dict(
+            eval_loss=loss.item(),
+            eval_mse=mse.item(),
+        )
+        return metrics
+
+    for step in range(FLAGS.total_steps):
+        batch = subsample_batch(train_dataset, FLAGS.batch_size)
+        batch = augment_batch(augmentation, batch)
+        metrics = train_step(step, batch)
+        metrics["step"] = step
+
+        if step % FLAGS.log_freq == 0:
+            wandb_logger.log(metrics)
+            pprint.pprint(metrics)
+
+        if step % FLAGS.eval_freq == 0:
+            eval_metrics = []
+            for _ in range(FLAGS.eval_batches):
+                batch = subsample_batch(test_dataset, FLAGS.batch_size)
+                eval_metrics.append(eval_step(batch))
+            eval_metrics = average_metrics(eval_metrics)
+            eval_metrics["step"] = step
+
+            if eval_metrics["eval_loss"] < best_loss:
+                best_loss = eval_metrics["eval_loss"]
+                best_loss_model = _clone_state_dict(policy)
+
+            if eval_metrics["eval_mse"] < best_mse:
+                best_mse = eval_metrics["eval_mse"]
+                best_mse_model = _clone_state_dict(policy)
+
+            eval_metrics["best_loss"] = best_loss
+            eval_metrics["best_mse"] = best_mse
+            wandb_logger.log(eval_metrics)
+            pprint.pprint(eval_metrics)
+
+            if FLAGS.save_model:
+                save_data = {
+                    "variant": variant,
+                    "step": step,
+                    "model_state_dict": _clone_state_dict(policy),
+                    "optimizer_state_dict": optimizer.state_dict(),
+                    "best_loss_model_state_dict": best_loss_model,
+                    "best_mse_model_state_dict": best_mse_model,
+                }
+                wandb_logger.save_pickle(save_data, "model.pkl")
+
+    if FLAGS.save_model:
+        save_data = {
+            "variant": variant,
+            "step": FLAGS.total_steps,
+            "model_state_dict": _clone_state_dict(policy),
+            "optimizer_state_dict": optimizer.state_dict(),
+            "best_loss_model_state_dict": best_loss_model,
+            "best_mse_model_state_dict": best_mse_model,
+        }
+        wandb_logger.save_pickle(save_data, "model.pkl")
+
+
+if __name__ == "__main__":
+    absl.app.run(main)

--- a/CalbleRouting_pytorch/src/data.py
+++ b/CalbleRouting_pytorch/src/data.py
@@ -1,0 +1,95 @@
+import numpy as np
+import torch
+
+from copy import deepcopy
+from torchvision.transforms import RandAugment, TrivialAugmentWide, AugMix
+
+
+def index_batch(batch, indices):
+    indexed = {}
+    for key in batch.keys():
+        indexed[key] = batch[key][indices, ...]
+    return indexed
+
+
+def partition_batch_train_test(batch, train_ratio, random=False):
+    length = batch[list(batch.keys())[0]].shape[0]
+    if random:
+        train_indices = np.random.rand(length) < train_ratio
+    else:
+        train_indices = np.linspace(0, 1, length) < train_ratio
+    train_batch = index_batch(batch, train_indices)
+    test_batch = index_batch(batch, ~train_indices)
+    return train_batch, test_batch
+
+
+def subsample_batch(batch, size):
+    length = batch[list(batch.keys())[0]].shape[0]
+    indices = np.random.randint(length, size=size)
+    return index_batch(batch, indices)
+
+
+def concatenate_batches(batches):
+    concatenated = {}
+    for key in batches[0].keys():
+        concatenated[key] = np.concatenate([batch[key] for batch in batches], axis=0)
+    return concatenated
+
+
+def split_batch(batch, batch_size):
+    batches = []
+    length = batch[list(batch.keys())[0]].shape[0]
+    keys = batch.keys()
+    for start in range(0, length, batch_size):
+        end = min(start + batch_size, length)
+        batches.append({key: batch[key][start:end, ...] for key in keys})
+    return batches
+
+
+def preprocess_robot_dataset(dataset, clip_action):
+    dataset = deepcopy(dataset)
+    for key in ("side_image", "wrist45_image", "wrist225_image"):
+        if key in dataset:
+            dataset[key] = dataset[key].astype(np.float32) / 255.0
+    if "action" in dataset.keys():
+        dataset["action"] = np.clip(
+            dataset["action"], -clip_action, clip_action
+        ).astype(np.float32)
+    dataset["robot_state"] = dataset["robot_state"].astype(np.float32)
+    return dataset
+
+
+def get_data_augmentation(augmentation):
+    if augmentation == "none":
+        return None
+    elif augmentation == "rand":
+        return torch.jit.script(RandAugment())
+    elif augmentation == "trivial":
+        return torch.jit.script(TrivialAugmentWide())
+    elif augmentation == "augmix":
+        return torch.jit.script(AugMix())
+    else:
+        raise ValueError("Unsupported augmentation type!")
+
+
+def augment_images(augmentation, image):
+    if augmentation is None:
+        return image
+
+    image = np.clip(image, 0.0, 1.0)
+    image = np.transpose((image * 255.0).astype(np.ubyte), (0, 3, 1, 2))
+    with torch.no_grad():
+        image_tensor = torch.from_numpy(image)
+        image_tensor = augmentation(image_tensor)
+        image = image_tensor.numpy()
+
+    image = np.transpose(image, (0, 2, 3, 1)).astype(np.float32) / 255.0
+    return image
+
+
+def augment_batch(augmentation, batch):
+    batch = deepcopy(batch)
+    for key in ("side_image", "wrist45_image", "wrist225_image"):
+        if key in batch:
+            batch[key] = augment_images(augmentation, batch[key])
+    return batch

--- a/CalbleRouting_pytorch/src/model.py
+++ b/CalbleRouting_pytorch/src/model.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+from typing import List, Sequence, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from ml_collections import ConfigDict
+from torchvision import models
+
+
+def atanh(x: torch.Tensor) -> torch.Tensor:
+    return 0.5 * (torch.log1p(x) - torch.log1p(-x))
+
+
+class FullyConnectedNetwork(nn.Module):
+    def __init__(self, output_dim: int, arch: str = "256-256"):
+        super().__init__()
+        layers: List[nn.Module] = []
+        hidden_sizes = [int(h) for h in arch.split("-") if h]
+        for hidden_size in hidden_sizes:
+            layers.append(nn.LazyLinear(hidden_size))
+            layers.append(nn.ReLU(inplace=True))
+        layers.append(nn.LazyLinear(output_dim))
+        self.network = nn.Sequential(*layers)
+
+    def forward(self, input_tensor: torch.Tensor) -> torch.Tensor:
+        return self.network(input_tensor)
+
+
+class ResNetBackbone(nn.Module):
+    def __init__(self, resnet_type: str):
+        super().__init__()
+        resnet_type = resnet_type.lower()
+        if resnet_type == "resnet18":
+            backbone = models.resnet18(weights=None)
+        elif resnet_type == "resnet34":
+            backbone = models.resnet34(weights=None)
+        elif resnet_type == "resnet50":
+            backbone = models.resnet50(weights=None)
+        elif resnet_type == "resnet101":
+            backbone = models.resnet101(weights=None)
+        elif resnet_type == "resnet152":
+            backbone = models.resnet152(weights=None)
+        elif resnet_type == "resnet200":
+            backbone = models.resnet152(weights=None)
+        else:
+            raise ValueError(f"Unsupported ResNet type: {resnet_type}")
+
+        self.stem = nn.Sequential(
+            backbone.conv1,
+            backbone.bn1,
+            backbone.relu,
+            backbone.maxpool,
+        )
+        self.layer1 = backbone.layer1
+        self.layer2 = backbone.layer2
+        self.layer3 = backbone.layer3
+        self.layer4 = backbone.layer4
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.stem(x)
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.layer3(x)
+        x = self.layer4(x)
+        return x
+
+
+class ResNetPolicy(nn.Module):
+    output_dim: int
+    config_updates: ConfigDict | None
+
+    def __init__(self, output_dim: int, config_updates: ConfigDict | None = None):
+        super().__init__()
+        self.output_dim = output_dim
+        self.config = self.get_default_config(config_updates)
+        self.share_resnet = self.config.share_resnet_between_views
+        if self.share_resnet:
+            self.shared_resnet = ResNetBackbone(self.config.resnet_type)
+        else:
+            self.resnets = nn.ModuleList()
+        if self.config.state_injection in ("full", "z_only"):
+            self.state_projection = nn.LazyLinear(self.config.state_projection_dim)
+        else:
+            self.state_projection = None
+        self.mlp = FullyConnectedNetwork(self.output_dim, self.config.mlp_arch)
+
+    @staticmethod
+    def get_default_config(updates=None):
+        config = ConfigDict()
+        config.resnet_type = "ResNet18"
+        config.spatial_aggregate = "average"
+        config.mlp_arch = "256-256"
+        config.state_injection = "full"
+        config.state_projection_dim = 64
+        config.share_resnet_between_views = True
+
+        if updates is not None:
+            config.update(ConfigDict(updates).copy_and_resolve_references())
+
+        return config
+
+    @staticmethod
+    def rng_keys():
+        return ()
+
+    @staticmethod
+    def get_weight_decay_exclusions():
+        return ("bias", "bn", "norm")
+
+    def _get_resnet_for_view(self, index: int) -> nn.Module:
+        if self.share_resnet:
+            return self.shared_resnet
+        if len(self.resnets) <= index:
+            for _ in range(index + 1 - len(self.resnets)):
+                self.resnets.append(ResNetBackbone(self.config.resnet_type))
+        return self.resnets[index]
+
+    def _process_image(self, image: torch.Tensor, index: int) -> torch.Tensor:
+        if image.dim() != 4:
+            raise ValueError("Images must have shape (B, H, W, C) or (B, C, H, W)")
+        if image.shape[1] not in (1, 3) and image.shape[-1] in (1, 3):
+            image = image.permute(0, 3, 1, 2)
+        image = image.contiguous()
+        resnet = self._get_resnet_for_view(index)
+        resnet = resnet.to(image.device)
+        return resnet(image)
+
+    def forward(self, state: torch.Tensor, images: Sequence[torch.Tensor], return_features: bool = False):
+        features: List[torch.Tensor] = []
+        for i, image in enumerate(images):
+            z = self._process_image(image, i)
+            if self.config.spatial_aggregate == "average":
+                z = z.mean(dim=(2, 3))
+            elif self.config.spatial_aggregate == "flatten":
+                z = z.flatten(start_dim=1)
+            else:
+                raise ValueError("Unsupported spatial aggregation type")
+            features.append(z)
+
+        if features:
+            state = state.to(features[0].device)
+
+        if self.config.state_injection == "full":
+            if self.state_projection is None:
+                raise ValueError("State projection not initialised")
+            projected = self.state_projection(state)
+            features.append(projected)
+        elif self.config.state_injection == "z_only":
+            if self.state_projection is None:
+                raise ValueError("State projection not initialised")
+            projected = self.state_projection(state[:, 2:3])
+            features.append(projected)
+        elif self.config.state_injection == "none":
+            pass
+        else:
+            raise ValueError(f"Unsupported state_injection: {self.config.state_injection}")
+
+        features_tensor = torch.cat(features, dim=1)
+        fc_out = self.mlp(features_tensor)
+        if return_features:
+            return features_tensor, fc_out
+        return fc_out
+
+
+class TanhGaussian:
+    def __init__(self, mean: torch.Tensor, log_std: torch.Tensor):
+        self.mean = mean
+        self.log_std = torch.clamp(log_std, -20.0, 2.0)
+        self.std = torch.exp(self.log_std)
+        self.normal = torch.distributions.Normal(self.mean, self.std)
+        self.base = torch.distributions.Independent(self.normal, 1)
+
+    def log_prob(self, value: torch.Tensor) -> torch.Tensor:
+        eps = 1e-6
+        clipped = torch.clamp(value, -1 + eps, 1 - eps)
+        pre_tanh = atanh(clipped)
+        log_det = torch.sum(torch.log1p(-clipped.pow(2) + eps), dim=-1)
+        base_log_prob = self.base.log_prob(pre_tanh)
+        return base_log_prob - log_det
+
+    def sample(self) -> Tuple[torch.Tensor, torch.Tensor]:
+        noise = torch.randn_like(self.mean)
+        pre_tanh = self.mean + self.std * noise
+        value = torch.tanh(pre_tanh)
+        log_prob = self.log_prob(value)
+        return value, log_prob
+
+    def deterministic_sample(self) -> Tuple[torch.Tensor, torch.Tensor]:
+        value = torch.tanh(self.mean)
+        log_prob = self.log_prob(value)
+        return value, log_prob
+
+
+class TanhGaussianResNetPolicy(nn.Module):
+    def __init__(self, output_dim: int, config_updates=None):
+        super().__init__()
+        self.backbone = ResNetPolicy(output_dim * 2, config_updates)
+
+    @staticmethod
+    def get_default_config(updates=None):
+        return ResNetPolicy.get_default_config(updates)
+
+    @staticmethod
+    def rng_keys():
+        return ()
+
+    @staticmethod
+    def get_weight_decay_exclusions():
+        return ResNetPolicy.get_weight_decay_exclusions()
+
+    def log_prob(self, state, action, images, return_mean=False):
+        gaussian_params = self.backbone(state, images)
+        mean, log_std = torch.chunk(gaussian_params, 2, dim=-1)
+        distribution = TanhGaussian(mean, log_std)
+        log_probs = distribution.log_prob(action)
+        if return_mean:
+            return log_probs, mean
+        return log_probs
+
+    def forward(self, state, images, deterministic=False):
+        gaussian_params = self.backbone(state, images)
+        mean, log_std = torch.chunk(gaussian_params, 2, dim=-1)
+        distribution = TanhGaussian(mean, log_std)
+        if deterministic:
+            samples, log_prob = distribution.deterministic_sample()
+        else:
+            samples, log_prob = distribution.sample()
+        return samples, log_prob
+
+
+class PretrainTanhGaussianResNetPolicy(nn.Module):
+    def __init__(self, output_dim: int, config_updates=None):
+        super().__init__()
+        self.backbone = ResNetPolicy(output_dim * 2, config_updates)
+
+    @staticmethod
+    def get_default_config(updates=None):
+        return ResNetPolicy.get_default_config(updates)
+
+    @staticmethod
+    def rng_keys():
+        return ()
+
+    @staticmethod
+    def get_weight_decay_exclusions():
+        return ResNetPolicy.get_weight_decay_exclusions()
+
+    def log_prob(self, state, action, images, return_mean=False):
+        gaussian_params = self.backbone(state, images)
+        mean, log_std = torch.chunk(gaussian_params, 2, dim=-1)
+        distribution = TanhGaussian(mean, log_std)
+        log_probs = distribution.log_prob(action)
+        if return_mean:
+            return log_probs, mean
+        return log_probs
+
+    def forward(self, state, images, deterministic=False, return_features=False):
+        features, gaussian_params = self.backbone(state, images, return_features=True)
+        mean, log_std = torch.chunk(gaussian_params, 2, dim=-1)
+        distribution = TanhGaussian(mean, log_std)
+        if deterministic:
+            samples, log_prob = distribution.deterministic_sample()
+        else:
+            samples, log_prob = distribution.sample()
+        if return_features:
+            return features, samples, log_prob
+        return samples, log_prob
+
+
+class PrimitiveSelectionPolicy(nn.Module):
+    def __init__(
+        self,
+        output_dim_gaussian_policy: int,
+        config_updates=None,
+        mlp_arch: str = "256-256",
+        total_num_primitives: int = 4,
+        num_embeddings: int = 5,
+        num_embedding_features: int = 4,
+        primitive_sequence_legnth: int = 6,
+    ):
+        super().__init__()
+        self.output_dim_gaussian_policy = output_dim_gaussian_policy
+        self.config = self.get_default_config(config_updates)
+        self.embed = nn.Embedding(
+            num_embeddings,
+            num_embedding_features,
+            padding_idx=0,
+        )
+        self.features_mlp = nn.Sequential(
+            nn.LazyLinear(256),
+            nn.ReLU(inplace=True),
+        )
+        self.sequence_length = primitive_sequence_legnth
+        self.primitive_mlp = nn.Sequential(
+            nn.LazyLinear(256),
+            nn.ReLU(inplace=True),
+        )
+        self.mlp = FullyConnectedNetwork(total_num_primitives, mlp_arch)
+
+    @staticmethod
+    def get_default_config(updates=None):
+        return ResNetPolicy.get_default_config(updates)
+
+    @staticmethod
+    def rng_keys():
+        return ()
+
+    @staticmethod
+    def get_weight_decay_exclusions():
+        return ("bias", "bn", "norm")
+
+    def forward(self, features: torch.Tensor, primitive_sequence: torch.Tensor, deterministic: bool = False):
+        if primitive_sequence.shape[-1] != self.sequence_length:
+            raise ValueError("primitive_sequence has incorrect length")
+        x = self.features_mlp(features)
+        primitives_embeddings = self.embed(primitive_sequence.long())
+        primitives_embeddings = primitives_embeddings.reshape(primitives_embeddings.shape[0], -1)
+        primitives_embeddings = self.primitive_mlp(primitives_embeddings)
+        embedding = torch.cat([x, primitives_embeddings], dim=-1)
+        logits = self.mlp(embedding)
+        return logits

--- a/CalbleRouting_pytorch/src/primitive_selection_main.py
+++ b/CalbleRouting_pytorch/src/primitive_selection_main.py
@@ -1,0 +1,274 @@
+import pprint
+
+import absl.app
+import absl.flags
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from .data import (
+    partition_batch_train_test,
+    subsample_batch,
+    preprocess_robot_dataset,
+    augment_batch,
+    get_data_augmentation,
+    concatenate_batches,
+)
+from .model import PrimitiveSelectionPolicy, PretrainTanhGaussianResNetPolicy
+from .utils import (
+    define_flags_with_default,
+    set_random_seed,
+    get_user_flags,
+    WandBLogger,
+    average_metrics,
+)
+from .train_utils import (
+    get_learning_rate,
+    get_optimizer,
+)
+
+import cloudpickle as pickle
+
+
+FLAGS_DEF = define_flags_with_default(
+    seed=42,
+    dataset_path="",
+    dataset_image_keys="side_image",
+    image_augmentation="none",
+    clip_action=0.99,
+    train_ratio=0.9,
+    batch_size=128,
+    total_steps=10000,
+    finetune_steps=500,
+    lr=1e-4,
+    lr_warmup_steps=0,
+    weight_decay=0.05,
+    clip_gradient=1e9,
+    log_freq=50,
+    eval_freq=200,
+    eval_batches=20,
+    save_model=False,
+    policy=PrimitiveSelectionPolicy.get_default_config(),
+    logger=WandBLogger.get_default_config(),
+    gripper=False,
+    encoder_checkpoint_path="",
+    primitive_policy_checkpoint_path="",
+    pretrained_model_key="model_state_dict",
+    output_dim_gaussian_policy=0,
+    finetune_policy=False,
+    device="auto",
+)
+
+FLAGS = absl.flags.FLAGS
+
+
+def _get_device(device_flag: str) -> torch.device:
+    if device_flag.lower() == "cpu":
+        return torch.device("cpu")
+    if device_flag.lower() == "cuda" and torch.cuda.is_available():
+        return torch.device("cuda")
+    if device_flag.lower() == "auto":
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    return torch.device(device_flag)
+
+
+def _to_device(array, device):
+    if isinstance(array, torch.Tensor):
+        tensor = array
+    else:
+        tensor = torch.from_numpy(np.asarray(array))
+    return tensor.to(device=device, dtype=torch.float32)
+
+
+def _clone_state_dict(model: torch.nn.Module):
+    return {k: v.detach().cpu().clone() for k, v in model.state_dict().items()}
+
+
+def load_policy_and_params(ckpt_path, policy_config, model_key):
+    assert ckpt_path != ""
+    with open(ckpt_path, "rb") as fin:
+        checkpoint_data = pickle.load(fin)
+    checkpoint_policy_config = {
+        k[7:]: v
+        for k, v in checkpoint_data.get("variant", {}).items()
+        if k.startswith("policy.")
+    }
+    if hasattr(policy_config, "update_from_flattened_dict"):
+        policy_config.update_from_flattened_dict(checkpoint_policy_config)
+    else:
+        for key, value in checkpoint_policy_config.items():
+            setattr(policy_config, key, value)
+    if model_key not in checkpoint_data:
+        raise KeyError(f"Key '{model_key}' not found in checkpoint")
+    params = checkpoint_data[model_key]
+    return policy_config, params
+
+
+def main(argv):
+    del argv
+    assert FLAGS.dataset_path != ""
+    variant = get_user_flags(FLAGS, FLAGS_DEF)
+    wandb_logger = WandBLogger(config=FLAGS.logger, variant=variant)
+    set_random_seed(FLAGS.seed)
+
+    image_keys = FLAGS.dataset_image_keys.split(":")
+    dataset_paths = FLAGS.dataset_path.split(":")
+    dataset = []
+    for dataset_path in dataset_paths:
+        loaded = np.load(dataset_path, allow_pickle=True)
+        if isinstance(loaded, np.ndarray) and loaded.shape == ():
+            loaded = loaded.item()
+        dataset.append(loaded)
+    dataset = concatenate_batches(dataset)
+    dataset = preprocess_robot_dataset(dataset, FLAGS.clip_action)
+    train_dataset, test_dataset = partition_batch_train_test(dataset, FLAGS.train_ratio)
+
+    pretrain_features_policy_config = PretrainTanhGaussianResNetPolicy.get_default_config()
+    (
+        pretrain_features_policy_config,
+        pretrain_features_policy_state_dict,
+    ) = load_policy_and_params(
+        FLAGS.encoder_checkpoint_path,
+        pretrain_features_policy_config,
+        FLAGS.pretrained_model_key,
+    )
+    pretrain_features_policy = PretrainTanhGaussianResNetPolicy(
+        output_dim=4,
+        config_updates=pretrain_features_policy_config,
+    )
+
+    device = _get_device(FLAGS.device)
+    pretrain_features_policy.load_state_dict(pretrain_features_policy_state_dict)
+    pretrain_features_policy.to(device)
+    pretrain_features_policy.eval()
+
+    policy_config = PrimitiveSelectionPolicy.get_default_config(FLAGS.policy)
+    policy_state_dict = None
+    if FLAGS.finetune_policy:
+        policy_config, policy_state_dict = load_policy_and_params(
+            FLAGS.primitive_policy_checkpoint_path,
+            policy_config,
+            FLAGS.pretrained_model_key,
+        )
+
+    policy = PrimitiveSelectionPolicy(
+        output_dim_gaussian_policy=FLAGS.output_dim_gaussian_policy,
+        config_updates=policy_config,
+    ).to(device)
+
+    if policy_state_dict is not None:
+        policy.load_state_dict(policy_state_dict)
+
+    learning_rate = get_learning_rate(FLAGS=FLAGS)
+    optimizer = get_optimizer(
+        model=policy,
+        learning_rate=FLAGS.lr,
+        weight_decay=FLAGS.weight_decay,
+        exclusions=PrimitiveSelectionPolicy.get_weight_decay_exclusions(),
+    )
+
+    augmentation = get_data_augmentation(FLAGS.image_augmentation)
+
+    best_loss = float("inf")
+    best_loss_model = None
+
+    train_steps = FLAGS.finetune_steps if FLAGS.finetune_policy else FLAGS.total_steps
+
+    def extract_features(state, images):
+        with torch.no_grad():
+            state_tensor = _to_device(state, device)
+            image_tensors = [_to_device(image, device) for image in images]
+            features, _, _ = pretrain_features_policy(
+                state_tensor,
+                image_tensors,
+                deterministic=True,
+                return_features=True,
+            )
+            return features.detach()
+
+    def train_step(step, batch):
+        policy.train()
+        features = extract_features(batch["robot_state"], [batch[key] for key in image_keys])
+        primitive_sequence = torch.from_numpy(batch["primitive_sequence"]).long().to(device)
+        labels = torch.from_numpy(batch["labels"]).long().to(device)
+        optimizer.zero_grad(set_to_none=True)
+        logits = policy(features, primitive_sequence)
+        loss = F.cross_entropy(logits, labels)
+        accuracy = (logits.argmax(dim=-1) == labels).float().mean()
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(policy.parameters(), FLAGS.clip_gradient)
+        current_lr = learning_rate(step)
+        for group in optimizer.param_groups:
+            group["lr"] = current_lr
+        optimizer.step()
+        metrics = dict(
+            loss=loss.item(),
+            train_accuracy=accuracy.item(),
+            learning_rate=current_lr,
+        )
+        return metrics
+
+    @torch.no_grad()
+    def eval_step(batch):
+        policy.eval()
+        features = extract_features(batch["robot_state"], [batch[key] for key in image_keys])
+        primitive_sequence = torch.from_numpy(batch["primitive_sequence"]).long().to(device)
+        labels = torch.from_numpy(batch["labels"]).long().to(device)
+        logits = policy(features, primitive_sequence)
+        loss = F.cross_entropy(logits, labels)
+        accuracy = (logits.argmax(dim=-1) == labels).float().mean()
+        metrics = dict(
+            eval_loss=loss.item(),
+            eval_accuracy=accuracy.item(),
+        )
+        return metrics
+
+    for step in range(train_steps):
+        batch = subsample_batch(train_dataset, FLAGS.batch_size)
+        batch = augment_batch(augmentation, batch)
+        metrics = train_step(step, batch)
+        metrics["step"] = step
+
+        if step % FLAGS.log_freq == 0:
+            wandb_logger.log(metrics)
+            pprint.pprint(metrics)
+
+        if step % FLAGS.eval_freq == 0:
+            eval_metrics = []
+            for _ in range(FLAGS.eval_batches):
+                batch = subsample_batch(test_dataset, FLAGS.batch_size)
+                eval_metrics.append(eval_step(batch))
+            eval_metrics = average_metrics(eval_metrics)
+            eval_metrics["step"] = step
+
+            if eval_metrics["eval_loss"] < best_loss:
+                best_loss = eval_metrics["eval_loss"]
+                best_loss_model = _clone_state_dict(policy)
+
+            eval_metrics["best_loss"] = best_loss
+            wandb_logger.log(eval_metrics)
+            pprint.pprint(eval_metrics)
+
+            if FLAGS.save_model:
+                save_data = {
+                    "variant": variant,
+                    "step": step,
+                    "model_state_dict": _clone_state_dict(policy),
+                    "optimizer_state_dict": optimizer.state_dict(),
+                    "best_loss_model_state_dict": best_loss_model,
+                }
+                wandb_logger.save_pickle(save_data, f"model.pkl")
+
+        if FLAGS.save_model and step in (0, train_steps - 1):
+            save_data = {
+                "variant": variant,
+                "step": step,
+                "model_state_dict": _clone_state_dict(policy),
+                "optimizer_state_dict": optimizer.state_dict(),
+                "best_loss_model_state_dict": best_loss_model,
+            }
+            wandb_logger.save_pickle(save_data, f"model_{step}_steps.pkl")
+
+
+if __name__ == "__main__":
+    absl.app.run(main)

--- a/CalbleRouting_pytorch/src/train_utils.py
+++ b/CalbleRouting_pytorch/src/train_utils.py
@@ -1,0 +1,54 @@
+import math
+import re
+from typing import Iterable, Sequence
+
+import torch
+
+
+def get_learning_rate(FLAGS, init=0.0, end=0.0):
+    warmup_steps = max(int(FLAGS.lr_warmup_steps), 0)
+    total_steps = max(int(FLAGS.total_steps), 1)
+    peak = float(FLAGS.lr)
+    init = float(init)
+    end = float(end)
+
+    def schedule(step: int) -> float:
+        step = max(int(step), 0)
+        if warmup_steps > 0 and step < warmup_steps:
+            return init + (peak - init) * (step / warmup_steps)
+        progress = min(max(step - warmup_steps, 0) / max(total_steps - warmup_steps, 1), 1.0)
+        cosine = 0.5 * (1.0 + math.cos(progress * math.pi))
+        return float(end + (peak - end) * cosine)
+
+    return schedule
+
+
+def _should_exclude(name: str, exclusions: Iterable[str]) -> bool:
+    for rule in exclusions:
+        if re.search(rule, name) is not None:
+            return True
+    return False
+
+
+def get_optimizer(model: torch.nn.Module, learning_rate: float, weight_decay: float, exclusions: Sequence[str]):
+    decay_params = []
+    no_decay_params = []
+    for name, param in model.named_parameters():
+        if not param.requires_grad:
+            continue
+        if exclusions and _should_exclude(name, exclusions):
+            no_decay_params.append(param)
+        else:
+            decay_params.append(param)
+
+    param_groups = []
+    if decay_params:
+        param_groups.append({"params": decay_params, "weight_decay": weight_decay})
+    if no_decay_params:
+        param_groups.append({"params": no_decay_params, "weight_decay": 0.0})
+
+    if not param_groups:
+        raise ValueError("No trainable parameters found")
+
+    optimizer = torch.optim.AdamW(param_groups, lr=learning_rate)
+    return optimizer

--- a/CalbleRouting_pytorch/src/utils.py
+++ b/CalbleRouting_pytorch/src/utils.py
@@ -1,0 +1,157 @@
+import os
+import random
+import tempfile
+import time
+import uuid
+
+import absl.flags
+import cloudpickle as pickle
+import numpy as np
+from copy import copy
+from socket import gethostname
+
+import torch
+import wandb
+
+from ml_collections import ConfigDict
+from ml_collections.config_flags import config_flags
+from ml_collections.config_dict import config_dict
+
+
+class WandBLogger(object):
+    @staticmethod
+    def get_default_config(updates=None):
+        config = ConfigDict()
+        config.online = False
+        config.prefix = "CableRouting"
+        config.project = "debug"
+        config.output_dir = "tmp/CableRouting"
+        config.random_delay = 0.0
+        config.experiment_id = config_dict.placeholder(str)
+        config.anonymous = config_dict.placeholder(str)
+        config.entity = config_dict.placeholder(str)
+        config.notes = config_dict.placeholder(str)
+
+        if updates is not None:
+            config.update(ConfigDict(updates).copy_and_resolve_references())
+        return config
+
+    def __init__(self, config, variant):
+        self.config = self.get_default_config(config)
+
+        if self.config.experiment_id is None:
+            self.config.experiment_id = uuid.uuid4().hex
+
+        if self.config.prefix != "":
+            self.config.project = "{}--{}".format(
+                self.config.prefix, self.config.project
+            )
+
+        if self.config.output_dir == "":
+            self.config.output_dir = tempfile.mkdtemp()
+        else:
+            self.config.output_dir = os.path.join(
+                self.config.output_dir, self.config.experiment_id
+            )
+            os.makedirs(self.config.output_dir, exist_ok=True)
+
+        self._variant = copy(variant)
+
+        if "hostname" not in self._variant:
+            self._variant["hostname"] = gethostname()
+
+        if self.config.random_delay > 0:
+            time.sleep(np.random.uniform(0, self.config.random_delay))
+
+        self.run = wandb.init(
+            reinit=True,
+            config=self._variant,
+            project=self.config.project,
+            dir=self.config.output_dir,
+            id=self.config.experiment_id,
+            anonymous=self.config.anonymous,
+            entity=self.config.entity,
+            notes=self.config.notes,
+            settings=wandb.Settings(
+                start_method="thread",
+                _disable_stats=True,
+            ),
+            mode="online" if self.config.online else "offline",
+        )
+
+    def log(self, *args, **kwargs):
+        self.run.log(*args, **kwargs)
+
+    def save_pickle(self, obj, filename):
+        with open(os.path.join(self.config.output_dir, filename), "wb") as fout:
+            pickle.dump(obj, fout)
+
+    @property
+    def experiment_id(self):
+        return self.config.experiment_id
+
+    @property
+    def variant(self):
+        return self.config.variant
+
+    @property
+    def output_dir(self):
+        return self.config.output_dir
+
+
+def define_flags_with_default(**kwargs):
+    for key, val in kwargs.items():
+        if isinstance(val, ConfigDict):
+            config_flags.DEFINE_config_dict(key, val)
+        elif isinstance(val, bool):
+            absl.flags.DEFINE_bool(key, val, "automatically defined flag")
+        elif isinstance(val, int):
+            absl.flags.DEFINE_integer(key, val, "automatically defined flag")
+        elif isinstance(val, float):
+            absl.flags.DEFINE_float(key, val, "automatically defined flag")
+        elif isinstance(val, str):
+            absl.flags.DEFINE_string(key, val, "automatically defined flag")
+        else:
+            raise ValueError("Incorrect value type")
+    return kwargs
+
+
+def set_random_seed(seed):
+    np.random.seed(seed)
+    random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def get_user_flags(flags, flags_def):
+    output = {}
+    for key in flags_def:
+        val = getattr(flags, key)
+        if isinstance(val, ConfigDict):
+            output.update(flatten_config_dict(val, prefix=key))
+        else:
+            output[key] = val
+
+    return output
+
+
+def flatten_config_dict(config, prefix=None):
+    output = {}
+    for key, val in config.items():
+        if prefix is not None:
+            next_prefix = "{}.{}".format(prefix, key)
+        else:
+            next_prefix = key
+        if isinstance(val, ConfigDict):
+            output.update(flatten_config_dict(val, prefix=next_prefix))
+        else:
+            output[next_prefix] = val
+    return output
+
+
+def average_metrics(metrics):
+    averaged = {}
+    for key in metrics[0].keys():
+        averaged[key] = float(np.mean([m[key] for m in metrics]))
+    return averaged


### PR DESCRIPTION
## Summary
- add a CalbleRouting_pytorch project directory that mirrors the original layout using PyTorch instead of JAX
- implement ResNet-based policies, behaviour cloning, and primitive selection training loops with PyTorch optimisers and checkpoint handling
- update data processing utilities, shell scripts, requirements, and documentation for the PyTorch workflow

## Testing
- python -m compileall CalbleRouting_pytorch/src
- python -m compileall CalbleRouting_pytorch/data

------
https://chatgpt.com/codex/tasks/task_e_68d41d241ec8832ea1a6d38f4eb34990